### PR TITLE
Install PHP CLI in the SSH container

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can provide some env variables via `.env` file:
 
 * `SSH_PASSWORD` (defaults to `p4ssw0rd`)
 * `WORDPRESS_DATABASE_PASSWORD` (defaults to `p4ssw0rd`)
+* `WORDPRESS_HTTP_PORT` (defaults to `8888`)
 
 > You can use `head -c 500 /dev/urandom | md5 | base64` to generate them.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     hostname: wordpress
     restart: on-failure
     ports:
-      - 8888:8080
+      - ${WORDPRESS_HTTP_PORT:-8888}:8080
     volumes:
       - "wordpress_data:/bitnami/wordpress"
       - "opt_bitnami_data:/opt/bitnami/wordpress"
@@ -55,7 +55,7 @@ services:
   # https://docs.linuxserver.io/images/docker-openssh-server
   # https://github.com/linuxserver/docker-openssh-server/pkgs/container/openssh-server
   ssh-dev:
-    image: ghcr.io/linuxserver/openssh-server:2021.11.21
+    image: ghcr.io/linuxserver/openssh-server:8.8_p1-r1-ls91
     hostname: openssh-server
     ports:
       - '62222:2222'
@@ -70,11 +70,16 @@ services:
       GUID: "0"
 
     volumes:
-      - "./ssh_key.pub:/tmp/key.pub"  # see the README.md file on how to regenerate the public key
+      # see the README.md file on how to regenerate the public key
+      - "./ssh_key.pub:/tmp/key.pub"
 
       # allow modifying WordPress files via SSH
       - "wordpress_data:/bitnami/wordpress"
       - "opt_bitnami_data:/opt/bitnami/wordpress"
+
+      # Install php-cli inside the ssh container
+      # https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers
+      - ./open-ssh-install-php.sh:/custom-cont-init.d/open-ssh-install-php.sh:ro
 
 volumes:
 

--- a/open-ssh-install-php.sh
+++ b/open-ssh-install-php.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+apk update && \
+	apk add php8-cli && \
+	ln -s /usr/bin/php8 /usr/bin/php && \
+	php -v && php -m


### PR DESCRIPTION
See https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers

```
$ docker-compose exec ssh-dev php -v
PHP 8.0.18 (cli) (built: Apr 22 2022 22:53:40) ( NTS ) Copyright (c) The PHP Group
Zend Engine v4.0.18, Copyright (c) Zend Technologies
```

And introduce `WORDPRESS_HTTP_PORT` env variable to customize the host port where WordPress is exposed on.