### PR TITLE
Pass database-related env variables to SSH session

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,14 @@ services:
       PUID: "1001"
       GUID: "0"
 
+      # expose these variables so that the shell will see them (see open-ssh-setup-env-vars.sh script below)
+      # wp-load.php is required in the SSH container and it needs to connect to the database
+      WORDPRESS_DATABASE_NAME: wp_db
+      WORDPRESS_DATABASE_USER: wp_user
+      WORDPRESS_DATABASE_PASSWORD: ${WORDPRESS_DATABASE_PASSWORD:-p4ssw0rd}
+
     volumes:
-      # see the README.md file on how to regenerate the public key
+      # see the README.md file on how to regenerate the keys pair
       - "./ssh_key.pub:/tmp/key.pub"
 
       # allow modifying WordPress files via SSH
@@ -79,7 +85,7 @@ services:
 
       # Install php-cli inside the ssh container
       # https://www.linuxserver.io/blog/2019-09-14-customizing-our-containers
-      - ./open-ssh-install-php.sh:/custom-cont-init.d/open-ssh-install-php.sh:ro
+      - ./open-ssh-setup.sh:/custom-cont-init.d/open-ssh-setup.sh:ro
 
 volumes:
 

--- a/open-ssh-install-php.sh
+++ b/open-ssh-install-php.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-apk update && \
-	apk add php8-cli php8-mysqli && \
-	ln -s /usr/bin/php8 /usr/bin/php && \
-	php -v && php -m

--- a/open-ssh-setup.sh
+++ b/open-ssh-setup.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+echo "> Installing PHP extensions ..."
+
+apk update && \
+	apk add php8-cli php8-mysqli && \
+	ln -s /usr/bin/php8 /usr/bin/php && \
+	php -v && php -m
+
+#
+#
+#
+
+# Create a script that will set up env variables for all SSH sessions
+# https://superuser.com/a/48787
+echo "> Setting up env variables for database access ..."
+
+SCRIPT_NAME='/config/.ssh/environment'
+
+echo "WORDPRESS_DATABASE_NAME=${WORDPRESS_DATABASE_NAME}" >> ${SCRIPT_NAME}
+echo "WORDPRESS_DATABASE_USER=${WORDPRESS_DATABASE_USER}" >> ${SCRIPT_NAME}
+echo "WORDPRESS_DATABASE_PASSWORD=${WORDPRESS_DATABASE_PASSWORD}" >> ${SCRIPT_NAME}
+
+cat ${SCRIPT_NAME}
+
+# tweak sshd configuration // https://www.freebsd.org/cgi/man.cgi?sshd_config(5)
+
+# allow ~/.ssh/environment file to set env variables
+echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config
+
+# and print the content of /etc/motd when logging in
+echo "PrintMotd yes" >> /etc/ssh/sshd_config
+
+#
+#
+#
+
+echo "> Redirecting OpenSSH daemon logs to stderr ..."
+echo "tail -f /config/logs/openssh/current >> /dev/stderr" > /sbin/logs_to_stderr.sh
+sh /sbin/logs_to_stderr.sh &


### PR DESCRIPTION
This way Jetpack's `canExec()` test will pass.

```
openssh-server:~$ php -r 'require_once "/opt/bitnami/wordpress/wp-load.php"; echo "Passed\n";'
PHP Warning:  Undefined array key "HTTP_HOST" in /bitnami/wordpress/wp-config.php on line 173
PHP Warning:  Undefined array key "HTTP_HOST" in /bitnami/wordpress/wp-config.php on line 174
Passed
```

This also makes OpenSSH daemon send logs to stderr, e.g.:

```
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:17:39.038721456  Failed password for wordpress from 172.30.0.1 port 64872 ssh2
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:17:53.296497690  Accepted password for wordpress from 172.30.0.1 port 64872 ssh2
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:17:53.314527495  Attempt to write login records by non-root user (aborting)
(...)
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:19:16.039597105  Attempt to write login records by non-root user (aborting)
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:19:16.042108737  Received disconnect from 172.30.0.1 port 64872:11: disconnected by user
test-wordpress-bitnami-ssh-dev-1    | 2022-09-12 13:19:16.042129410  Disconnected from user wordpress 172.30.0.1 port 64872
```