### PR TITLE
.wp-cli/config.yml - mount for the root user as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
 
           # list config settings
           ssh_wp wp config get --format=dotenv | grep WP_
+          docker-compose exec -T ssh-dev wp config get | grep WP_
 
           # list files
           ssh_wp id

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can provide some env variables via `.env` file:
 [`wp-cli` tool](https://wp-cli.org/) is installed in both WordPress and SSH containers.
 
 ```
-$ docker-compose exec ssh-dev wp post list --path=/opt/bitnami/wordpress/
+$ docker-compose exec ssh-dev wp post list
 +----+--------------+-------------+---------------------+-------------+
 | ID | post_title   | post_name   | post_date           | post_status |
 +----+--------------+-------------+---------------------+-------------+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       # wp-cli YAML config file
       # https://make.wordpress.org/cli/handbook/references/config/#config-files
       - ./wp-cli-config.yml:/home/wordpress/.wp-cli/config.yml:ro
+      - ./wp-cli-config.yml:/root/.wp-cli/config.yml:ro
 
 volumes:
 


### PR DESCRIPTION
So that the following is also possible:

```
$ docker-compose exec ssh-dev wp config get
+------------------------------+------------------------------------------------------------------+----------+
| name                         | value                                                            | type     |
+------------------------------+------------------------------------------------------------------+----------+
| table_prefix                 | wp_                                                              | variable |
| DB_NAME                      | wp_db                                                            | constant |
| DB_USER                      | wp_user                                                          | constant |
(...)
```

```
$ docker-compose exec ssh-dev wp cli info
OS:	Linux 5.10.0-7-amd64 #1 SMP Debian 5.10.40-1 (2021-05-28) x86_64
Shell:	
PHP binary:	/usr/bin/php8
PHP version:	8.0.18
php.ini used:	/etc/php8/php.ini
MySQL binary:	
MySQL version:	
SQL modes:	
WP-CLI root dir:	phar://wp-cli.phar/vendor/wp-cli/wp-cli
WP-CLI vendor dir:	phar://wp-cli.phar/vendor
WP_CLI phar path:	/
WP-CLI packages dir:	
WP-CLI global config:	/root/.wp-cli/config.yml
WP-CLI project config:	
WP-CLI version:	2.6.0
```