### PR TITLE
Add Traefik labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       run: |
         set -x
         ssh-keygen -t ed25519 -f ssh_key -N ''
+        
+        docker network create public-network
         docker-compose up -d
 
     - name: Wait for the WordPress container to be up

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can provide some env variables via `.env` file:
 * `SSH_PASSWORD` (defaults to `p4ssw0rd`)
 * `WORDPRESS_DATABASE_PASSWORD` (defaults to `p4ssw0rd`)
 * `WORDPRESS_SITE_URL` (defaults to `http://localhost:8888`)
+* `WORDPRESS_HOSTNAME` (used to add routing label for Traefik, e.g. `wptest.myself.dev`)
 * `WORDPRESS_HTTP_PORT` (defaults to `8888`)
 
 > You can use `head -c 500 /dev/urandom | md5 | base64` to generate them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       traefik.http.routers.wordpress.tls.certresolver: letsencrypt
       traefik.http.routers.wordpress.rule: Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)
       # https://doc.traefik.io/traefik/routing/services/#health-check
+      traefik.http.services.wordpress.loadbalancer.server.port: ${WORDPRESS_HTTP_PORT:-8888}
       traefik.http.services.wordpress.loadbalancer.healthCheck.path: /wp-json/
       traefik.http.services.wordpress.loadbalancer.healthCheck.method: HEAD
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       traefik.http.services.wordpress.loadbalancer.healthCheck.method: "HEAD"
       traefik.http.services.wordpress.loadbalancer.healthCheck.scheme: "http"
       traefik.http.services.wordpress.loadbalancer.healthCheck.interval: "10s"
-      traefik.http.services.wordpress.loadbalancer.healthCheck.hostname: "wordpress"
 
     healthcheck:
       test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,14 +42,13 @@ services:
       traefik.enable: true
       traefik.http.routers.wordpress.tls.certresolver: letsencrypt
       traefik.http.routers.wordpress.rule: Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)
-      traefik.http.services.wordpress.loadbalancer.server.port: 8080
       # https://doc.traefik.io/traefik/routing/services/#health-check
       traefik.http.services.wordpress.loadbalancer.healthCheck.path: /wp-json/
       traefik.http.services.wordpress.loadbalancer.healthCheck.method: HEAD
 
     healthcheck:
       test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'
-      interval: 10s
+      interval: 1m
       timeout: 1s
       retries: 5
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,15 @@ services:
       - "wordpress_data:/bitnami/wordpress"
       - "opt_bitnami_data:/opt/bitnami/wordpress"
 
+    # https://doc.traefik.io/traefik/user-guides/docker-compose/basic-example/
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)"
+      - "traefik.http.services.wordpress.loadbalancer.server.port=8080"
+      - "traefik.http.services.wordpress.loadBalancer.healthCheck.path=/wp-json/"
+      - "traefik.http.services.wordpress.loadBalancer.healthCheck.method=HEAD"
+
     healthcheck:
       test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'
       interval: 1m
@@ -109,3 +118,12 @@ volumes:
   mariadb:
   opt_bitnami_data:
   wordpress_data:
+
+# make the wordpress container discoverable by traefik
+# https://docs.docker.com/compose/networking/#configure-the-default-network
+#
+# docker network create public-network
+networks:
+  default:
+    name: public-network
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
       traefik.http.services.wordpress.loadbalancer.healthCheck.interval: "10s"
 
     healthcheck:
-      test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'
-      interval: 1m
+      test: 'pgrep nginx'
+      interval: 10s
       timeout: 1s
       retries: 5
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,16 +39,17 @@ services:
 
     # https://doc.traefik.io/traefik/user-guides/docker-compose/basic-example/
     labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.wordpress.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)"
-      - "traefik.http.services.wordpress.loadbalancer.server.port=8080"
-      - "traefik.http.services.wordpress.loadBalancer.healthCheck.path=/wp-json/"
-      - "traefik.http.services.wordpress.loadBalancer.healthCheck.method=HEAD"
+      traefik.enable: true
+      traefik.http.routers.wordpress.tls.certresolver: letsencrypt
+      traefik.http.routers.wordpress.rule: Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)
+      traefik.http.services.wordpress.loadbalancer.server.port: 8080
+      # https://doc.traefik.io/traefik/routing/services/#health-check
+      traefik.http.services.wordpress.loadbalancer.healthCheck.path: /wp-json/
+      traefik.http.services.wordpress.loadbalancer.healthCheck.method: HEAD
 
     healthcheck:
       test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'
-      interval: 1m
+      interval: 10s
       timeout: 1s
       retries: 5
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,14 @@ services:
       traefik.enable: true
       traefik.http.routers.wordpress.tls.certresolver: letsencrypt
       traefik.http.routers.wordpress.rule: Host(`${WORDPRESS_HOSTNAME:-wptest.dev.local}`)
+      # https://doc.traefik.io/traefik/routing/services/#servers
+      traefik.http.services.wordpress.loadbalancer.server.port: "8080"
       # https://doc.traefik.io/traefik/routing/services/#health-check
-      traefik.http.services.wordpress.loadbalancer.server.port: ${WORDPRESS_HTTP_PORT:-8888}
-      traefik.http.services.wordpress.loadbalancer.healthCheck.path: /wp-json/
-      traefik.http.services.wordpress.loadbalancer.healthCheck.method: HEAD
+      traefik.http.services.wordpress.loadbalancer.healthCheck.path: "/wp-json"
+      traefik.http.services.wordpress.loadbalancer.healthCheck.method: "HEAD"
+      traefik.http.services.wordpress.loadbalancer.healthCheck.scheme: "http"
+      traefik.http.services.wordpress.loadbalancer.healthCheck.interval: "10s"
+      traefik.http.services.wordpress.loadbalancer.healthCheck.hostname: "wordpress"
 
     healthcheck:
       test: 'curl http://0.0.0.0:8080/wp-json/ -sI -H "User-Agent: curl/healthcheck"'


### PR DESCRIPTION
See https://github.com/macbre/docker-traefik

When `docker-compose up` you'll get: `ERROR: Network public-network declared as external, but could not be found. Please create the network manually using `docker network create public-network` and try again.`

So run:

```
docker network create public-network
```

And have `.env` set up:

```
WORDPRESS_HTTP_PORT=8181
WORDPRESS_SITE_URL="https://wptest.macbre.net/"
WORDPRESS_HOSTNAME=wptest.macbre.net
```