### PR TITLE
open-ssh: install php-gd extension (allow wp media import to work)

### DIFF
--- a/open-ssh-setup.sh
+++ b/open-ssh-setup.sh
@@ -7,7 +7,7 @@ echo "> Installing PHP extensions and some utilities ..."
 
 apk update && \
 	apk add vim && \
-	apk add php8-cli php8-mysqli php8-xml && \
+	apk add php8-cli php8-gd php8-mysqli php8-xml && \
 	ln -sf /usr/bin/php8 /usr/bin/php && \
 	php -v && php -m
 


### PR DESCRIPTION
```
$ wp media import https://picsum.photos/450/450 --title="A test image"
Error: No support for generating images found. Please install the Imagick or GD PHP extensions.
```

With the change:

```
$ docker-compose exec ssh-dev php -m | grep gd
gd
```