### PR TITLE
Redis: bump to v7.4.0 + skip AOF and RDB files writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
 
   # https://hub.docker.com/_/redis 
   redis:
-    image: redis:7.2.1-alpine
+    image: redis:7.4.0-alpine
     hostname: wp-redis
     restart: unless-stopped
     ports:
@@ -130,12 +130,13 @@ services:
 
     mem_limit: 192M
 
+    command: redis-server /opt/redis.conf
     volumes:
-      - "redis_data:/data"
+      - "./redis.conf:/opt/redis.conf:ro"
 
     healthcheck:
       test: 'redis-cli ping'
-      interval: 20s
+      interval: 5s
       timeout: 1s
       retries: 3
 

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,5 @@
+# disable the aof
+appendonly no
+
+# disable the rdb
+save ""


### PR DESCRIPTION
Otherwise the Redis volume can grow to GBs.